### PR TITLE
(fix) Add null check, reduce load on map creation, fix incorrect max …

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -4,6 +4,7 @@
 # Logging
 #
 # Add these lines to your worldserver.conf file to enable logging for AutoBalance.
+# Be sure to add them after the `Logger.module=4,Console Server` line.
 #
 # 4 = Info (Default), 5 = Debug
 #


### PR DESCRIPTION
…health on some creatures (#171)

* Only skip critters that are flavor-only (<= level 5)

* Refactor to break out some logic into separate functions.

* Refactor more repeated operations into separate functions
- Add worldHealthMultiplier, intended to be used to scale the health of attackable game objects in the instance

* Continued refinement of non-creature-based damage and healing

* Rework damage handling, improve coverage, debug logging
- tear out and re-implement all the damage handling to ensure more cases are handled
- use the map's damage modifier when damage happens where the source isn't a creature
- better handle when the source of damage no longer exists (logged out or despawned)
- extensive (optional) logging under the `module.AutoBalance.Damage` logging prefix
- WIP implementattion of game object damage handling (destructible buildings)
- fix a long-standing error in the class name for some logging

* World damage scaling is working, WIP
- need to apply statmodifiers still
- improved logging

* - many, many logging improvements
- fix a bug with the enable check case statements (stupid case breaks)
- remove antiquated battleground checks - should never scale in battlegrounds
- better handle "special" creatures (totems, triggers, critters)
- allow combat critters to scale correctly
- allow intentionally-low-level triggers and critters to remain low level
- workaround an issue with summons showing the wrong level client-side (level change ramp up)
- further improve GM and user commands
- erase map AB info from maps when they are created, preventing issues with instance ID re-use
- better handle instances with no non-GM characters (disable scaling temporarily)

* Further work on summoned creatures, still WIP
- removed unnecessary `std::string`s

* WIP

* Rewrite multiplier calculation, reduce required processing
- majory re-wrote the multiplicer calculations to increase accuracy and clarity
- take advantage of new `OnBeforeCreatureSelectLevel` hook to set the initial level of creatures before they are added to the world
- separated level-scaled and non-level-scaled multipliers for tracking and display
- move creature relevancy check to new function `isCreatureRelevant`
- rename many variables to standardize and clarify
- add option to force a map stats update, to be used when a player enters the map
- players leaving the map are no longer included in the map's stats
- sweeping improvements in logging of the multiplier calculation process (`AutoBalance.StatGeneration`)
- update `.ab creaturestat` to show new scaled modifiers in an understandable way

* Optimize map updates to only occur when necessary. WIP.

* Create documentation for Info classes, add player lists

* Reworking config tracking, WIP

* Rewrite player tracking to remove kludges, many improvements
- replace kludgy player count detection with an internal player list (more features coming Soon)
- skip scaling on player-owned summons, totems, etc
- skip scaling on flavor critters but not on combat critters
- separate map and global config times, reducing the work to refresh if only a map config changes
- centralize detection of "non-relevant" creatures, use a `skipMe` tag to speed up processing
- correctly handle a GM leaving the instance who was previously a non-GM when they entered
- temporarily disable in-combat checking
- improve logging format to produce the ID needed for `.go creature <UUID>`
- standardize logging format

* Performance improvements, fix statmodifier selection, logging
- moved enums to top the file, added `Relevance` enum
- improve performance of `isCreatureRelevant` but saving the decision from previous runs
- fix issues with summon detection to (hopefully) cover all edge cases
- consolidate and fix StatModifier case selection, add debugs
- more logging improvements all around

* Recount players on a config reload.

* Improve player enter/leave behavior.

* Improve handling of empty instances, properly scale trigger creatures, improve `.ab mapstat`

* Check that the target for `.ab creaturestat` is in a dungeon.

* Move boss detection to separate function
- boss summons now also count as a "boss"

* Do not modify spells that hurt the player but are intended to - Dark Runes, etc
- logging improvements

* Fix world multipliers not getting reloaded. Logging improvements.

* Additional debug for boss detection

* Fix percent-based damage auras, map multipliers honor level scaling
- percent-based damage auras will now ignore level scaling (per-player scaling only)
- map multipliers (damage/healing and health) will now honor the level scaling setting
- use a custom struct to store and move around world multipliers
- properly remove LevelScalingEndGameBoost until it can be fixed (#156)
- creatures summoned by a boss will now be scaled like bosses
- further refinement of trigger handling logic
- fix active creature not being decremented on creature removal
- fix incorrect announcing of GMs entering/exiting the instance
- improvements for in-game commands
- continued log improvements

* World multipliers now honor stat modifiers
- logging improvements

* Re-enable the processing of map stats when the instance is empty

* Combat locking: WIP

* Combat locking - better implementation. WIP, needs notifications.

* Re-implement combat locking

* Complete migration from skipMe to isCreatureRelevant

* Code and log cleanup

* Handle a combatLockMinPlayers of 0

* Update bug report template to request AB-specific information

* Update README.md with commands, loggers, and min AC version

* Add logging settings to .conf.dist file. Small logging change.

* Replace uint with uint8.

* Rename `GetCurrentTime()` and remove case ranges to make Windows happy

* Code cleanup. Replace case statements. Remove `entry`, which is unneeded.

* (Hopefully) final code cleanup, comment refinement

* Fix enemy totems not level scaling. Update logging statement.

* Resolve issue with heroic dungeons that don't have LFG levels defined

* Fix dungeon difficulty normal, add error logging if no LFG found

* Fix incorrect heroic settings.
- fix display issue with active creatures

* Fix syntax error.
- that'll teach me to commit before I build

* Handle cloned summons, improve creaturestat command
- track summoner as a part of AutoBalanceCreatureInfo
- detect when a summon is a clone and use the correct current health instead of scaling again
- add summon information to `.ab creaturestat`
- as always, logging improvements

* Handle shared damage auras, add never modify spells
- spells with SPELL_AURA_SHARE_DAMAGE_PCT effects will now correctly be unmodified
- added `spellIdsToNeverModify` and correctly skip modification of them
- add "Twin Empathy" (1177) to the `spellIdsToNeverModify` list
- convert `_IsAuraPercentDamage` to `_isAuraWithEffectType` since this probably isn't the last I'll need it
- logging changes, naturally

* Move initial scaling from first OnAllCreatureUpdate to Creature_SelectLevel

* Tell user to move logging settings to `worldserver.conf`, since they don't work well in module config

* Fix combat locking.

* Small update to spellIdsToNeverModify

* Move warning to debug.

* Add creatureIDsThatAreNotClones. Fix crash.

* Check spellIdsToNeverModify for game object damage too

* Add important logging hint

* Attempt to resolve crash for non-standard class/race combinations

* Remove disabling instance when no non-GMs in the map. Add extra SetHealth/SetMaxHealth just before adding creatures to the world.
- Fixes #168
- Fixes #169

* Remove hack-ish health set. Set instance min of 1. Reduce unneeded calculations.

* Restore our modified max health just after the creature is added to the world, if necessary

* Fix mis-used of health function.

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
